### PR TITLE
Loosen bounds for `mwc-random`

### DIFF
--- a/stm-hamt.cabal
+++ b/stm-hamt.cabal
@@ -76,7 +76,7 @@ benchmark concurrent-insertion-bench
     focus,
     free >=4.5 && <6,
     list-t,
-    mwc-random >=0.13 && <0.15,
+    mwc-random >=0.13 && <0.16,
     mwc-random-monad ==0.7.*,
     rebase <2,
     stm-hamt


### PR DESCRIPTION
This allows `stm-hamt` to be compiled with `mwc-random-0.15.*`. I've checked that the package compiles correctly. This PR is in response to https://github.com/commercialhaskell/stackage/issues/5557.