### PR TITLE
Restrict lower bound on `hashable`

### DIFF
--- a/stm-hamt.cabal
+++ b/stm-hamt.cabal
@@ -78,7 +78,7 @@ library
       base >=4.9 && <5
     , deferred-folds >=0.9 && <0.10
     , focus >=1 && <1.1
-    , hashable <2
+    , hashable >=1.4.0.0 && <2
     , list-t >=1.0.1 && <1.1
     , primitive >=0.7 && <0.9
     , primitive-extras >=0.10 && <0.11


### PR DESCRIPTION
Pre 1.4 don't have `Eq` as a superclass constraint, therefore code doesn't build with those.

```
❯ cabal build --constraint "hashable ^>=1.4"
Resolving dependencies...
Build profile: -w ghc-9.2.5 -O1
In order, the following will be built (use -v for more details):
 - stm-hamt-1.2.0.10 (lib) (first run)
Warning: stm-hamt.cabal:20:21: Packages with 'cabal-version: 1.12' or later
should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 2.0'.
Configuring library for stm-hamt-1.2.0.10..
Preprocessing library for stm-hamt-1.2.0.10..
Building library for stm-hamt-1.2.0.10..
[1 of 9] Compiling StmHamt.Prelude  ( library/StmHamt/Prelude.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Prelude.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Prelude.dyn_o )
[2 of 9] Compiling StmHamt.IntOps   ( library/StmHamt/IntOps.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/IntOps.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/IntOps.dyn_o )
[3 of 9] Compiling StmHamt.Types    ( library/StmHamt/Types.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Types.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Types.dyn_o )
[4 of 9] Compiling StmHamt.ListT    ( library/StmHamt/ListT.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/ListT.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/ListT.dyn_o )
[5 of 9] Compiling StmHamt.Constructors.Branch ( library/StmHamt/Constructors/Branch.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Constructors/Branch.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Constructors/Branch.dyn_o )
[6 of 9] Compiling StmHamt.Focuses  ( library/StmHamt/Focuses.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Focuses.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Focuses.dyn_o )
[7 of 9] Compiling StmHamt.UnfoldlM ( library/StmHamt/UnfoldlM.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/UnfoldlM.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/UnfoldlM.dyn_o )
[8 of 9] Compiling StmHamt.Hamt     ( library/StmHamt/Hamt.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Hamt.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Hamt.dyn_o )
[9 of 9] Compiling StmHamt.SizedHamt ( library/StmHamt/SizedHamt.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/SizedHamt.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/SizedHamt.dyn_o )
```

Versus

```
❯ cabal build --constraint "hashable == 1.3.5.0"
Resolving dependencies...
Build profile: -w ghc-9.2.5 -O1
In order, the following will be built (use -v for more details):
 - stm-hamt-1.2.0.10 (lib) (configuration changed)
Warning: stm-hamt.cabal:20:21: Packages with 'cabal-version: 1.12' or later
should specify a specific version of the Cabal spec of the form
'cabal-version: x.y'. Use 'cabal-version: 2.0'.
Configuring library for stm-hamt-1.2.0.10..
Preprocessing library for stm-hamt-1.2.0.10..
Building library for stm-hamt-1.2.0.10..
[1 of 9] Compiling StmHamt.Prelude  ( library/StmHamt/Prelude.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Prelude.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Prelude.dyn_o ) [PrimitiveExtras.By6Bits changed]
[2 of 9] Compiling StmHamt.IntOps   ( library/StmHamt/IntOps.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/IntOps.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/IntOps.dyn_o ) [StmHamt.Prelude changed]
[3 of 9] Compiling StmHamt.Types    ( library/StmHamt/Types.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Types.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Types.dyn_o ) [StmHamt.Prelude changed]
[4 of 9] Compiling StmHamt.ListT    ( library/StmHamt/ListT.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/ListT.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/ListT.dyn_o ) [PrimitiveExtras.SmallArray changed]
[5 of 9] Compiling StmHamt.Constructors.Branch ( library/StmHamt/Constructors/Branch.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Constructors/Branch.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Constructors/Branch.dyn_o ) [PrimitiveExtras.By6Bits changed]
[6 of 9] Compiling StmHamt.Focuses  ( library/StmHamt/Focuses.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Focuses.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Focuses.dyn_o ) [PrimitiveExtras.SmallArray changed]
[7 of 9] Compiling StmHamt.UnfoldlM ( library/StmHamt/UnfoldlM.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/UnfoldlM.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/UnfoldlM.dyn_o ) [PrimitiveExtras.SmallArray changed]
[8 of 9] Compiling StmHamt.Hamt     ( library/StmHamt/Hamt.hs, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Hamt.o, /home/javier/stm-hamt/dist-newstyle/build/x86_64-linux/ghc-9.2.5/stm-hamt-1.2.0.10/build/StmHamt/Hamt.dyn_o ) [PrimitiveExtras.SmallArray changed]

library/StmHamt/Hamt.hs:34:66: error:
    • Could not deduce (Eq key) arising from a use of ‘==’
      from the context: Hashable key
        bound by the type signature for:
                   focus :: forall key element result.
                            Hashable key =>
                            Focus element STM result
                            -> (element -> key) -> key -> Hamt element -> STM result
        at library/StmHamt/Hamt.hs:33:1-108
      Possible fix:
        add (Eq key) to the context of
          the type signature for:
            focus :: forall key element result.
                     Hashable key =>
                     Focus element STM result
                     -> (element -> key) -> key -> Hamt element -> STM result
    • In the first argument of ‘(.)’, namely ‘(==) key’
      In the third argument of ‘focusExplicitly’, namely
        ‘((==) key . elementToKey)’
      In the expression:
        focusExplicitly focus (hash key) ((==) key . elementToKey)
   |
34 | focus focus elementToKey key = focusExplicitly focus (hash key) ((==) key . elementToKey)
   |                                                                  ^^^^

library/StmHamt/Hamt.hs:47:36: error:
    • Could not deduce (Eq key) arising from a use of ‘==’
      from the context: Hashable key
        bound by the type signature for:
                   insert :: forall key element.
                             Hashable key =>
                             (element -> key) -> element -> Hamt element -> STM Bool
        at library/StmHamt/Hamt.hs:44:1-83
      Possible fix:
        add (Eq key) to the context of
          the type signature for:
            insert :: forall key element.
                      Hashable key =>
                      (element -> key) -> element -> Hamt element -> STM Bool
    • In the first argument of ‘(.)’, namely ‘(==) key’
      In the second argument of ‘insertExplicitly’, namely
        ‘((==) key . elementToKey)’
      In the expression:
        insertExplicitly (hash key) ((==) key . elementToKey) element
   |
47 |    in insertExplicitly (hash key) ((==) key . elementToKey) element
   |                                    ^^^^

library/StmHamt/Hamt.hs:100:56: error:
    • Could not deduce (Eq key) arising from a use of ‘==’
      from the context: Hashable key
        bound by the type signature for:
                   lookup :: forall key element.
                             Hashable key =>
                             (element -> key) -> key -> Hamt element -> STM (Maybe element)
        at library/StmHamt/Hamt.hs:99:1-90
      Possible fix:
        add (Eq key) to the context of
          the type signature for:
            lookup :: forall key element.
                      Hashable key =>
                      (element -> key) -> key -> Hamt element -> STM (Maybe element)
    • In the first argument of ‘(.)’, namely ‘(==) key’
      In the second argument of ‘lookupExplicitly’, namely
        ‘((==) key . elementToKey)’
      In the expression:
        lookupExplicitly (hash key) ((==) key . elementToKey)
    |
100 | lookup elementToKey key = lookupExplicitly (hash key) ((==) key . elementToKey)
    |                                                        ^^^^
Error: cabal: Failed to build stm-hamt-1.2.0.10.
```