### PR TITLE
feat: Add non-atomic listT variant

### DIFF
--- a/library/StmHamt/Hamt.hs
+++ b/library/StmHamt/Hamt.hs
@@ -12,6 +12,7 @@ module StmHamt.Hamt
     reset,
     unfoldlM,
     listT,
+    listTNonAtomic,
   )
 where
 
@@ -124,6 +125,9 @@ unfoldlM = UnfoldlM.hamtElements
 
 listT :: Hamt a -> ListT STM a
 listT = ListT.hamtElements
+
+listTNonAtomic :: Hamt a -> ListT IO a
+listTNonAtomic = ListT.hamtElementsNonAtomic
 
 null :: Hamt a -> STM Bool
 null (Hamt branchSsaVar) = do

--- a/library/StmHamt/ListT.hs
+++ b/library/StmHamt/ListT.hs
@@ -1,5 +1,6 @@
 module StmHamt.ListT where
 
+import qualified Control.Concurrent.STM as STM
 import ListT
 import qualified PrimitiveExtras.By6Bits as By6Bits
 import qualified PrimitiveExtras.SmallArray as SmallArray
@@ -9,10 +10,21 @@ import StmHamt.Types
 hamtElements :: Hamt a -> ListT STM a
 hamtElements (Hamt var) = tVarValue var >>= By6Bits.elementsListT >>= branchElements
 
+hamtElementsNonAtomic :: Hamt a -> ListT IO a
+hamtElementsNonAtomic (Hamt var) = tVarValueIO var >>= By6Bits.elementsListT >>= branchElementsNonAtomic
+
 branchElements :: Branch a -> ListT STM a
 branchElements = \case
   LeavesBranch _ array -> SmallArray.elementsListT array
   BranchesBranch hamt -> hamtElements hamt
 
+branchElementsNonAtomic :: Branch a -> ListT IO a
+branchElementsNonAtomic = \case
+  LeavesBranch _ array -> SmallArray.elementsListT array
+  BranchesBranch hamt -> hamtElementsNonAtomic hamt
+
 tVarValue :: TVar a -> ListT STM a
 tVarValue var = lift (readTVar var)
+
+tVarValueIO :: TVar a -> ListT IO a
+tVarValueIO var = lift (readTVarIO var)

--- a/stm-hamt.cabal
+++ b/stm-hamt.cabal
@@ -83,6 +83,7 @@ library
     , list-t >=1.0.1 && <1.1
     , primitive >=0.7 && <0.10
     , primitive-extras >=0.10 && <0.11
+    , stm
     , transformers >=0.5 && <0.7
 
 test-suite test


### PR DESCRIPTION
This will be used to implement
https://github.com/nikita-volkov/stm-containers/issues/32

For use when you need to iterate over the HAMT, and would prefer potentially out-of-date/inconsistent data, to starvation.

Depends on https://github.com/nikita-volkov/primitive-extras/pull/8